### PR TITLE
Fix: Open location details on valid location id

### DIFF
--- a/feature/characters/src/main/kotlin/com/stathis/characters/ui/details/components/CharacterDetailsRow.kt
+++ b/feature/characters/src/main/kotlin/com/stathis/characters/ui/details/components/CharacterDetailsRow.kt
@@ -49,7 +49,7 @@ internal fun CharacterDetailsRow(
             locationName = origin.name,
             locationType = origin.type,
             dimension = origin.dimension,
-            onClick = { onLocationClick(origin.id) }
+            onClick = { origin.id.onSafeLocationClick(onLocationClick) }
         )
         Spacer(modifier = Modifier.height(dimensionResource(DimenRes.dimen_10)))
         CharacterLocation(
@@ -57,10 +57,17 @@ internal fun CharacterDetailsRow(
             locationName = currentLocation.name,
             locationType = currentLocation.type,
             dimension = currentLocation.dimension,
-            onClick = { onLocationClick(currentLocation.id) }
+            onClick = { currentLocation.id.onSafeLocationClick(onLocationClick) }
         )
     }
 }
+
+/**
+ * Helper fun to wrap the onLocationClick callback since when a location
+ * is unavailable (doesn't exist) it has an id of zero (0).
+ */
+
+private fun Int.onSafeLocationClick(callback: (Int) -> Unit) = takeIf { it > 0 }?.let { callback.invoke(it) }
 
 @Preview
 @Composable


### PR DESCRIPTION
### Problem
After the feature about being able to navigate from the character details to the location details screen has been added in the app, if a user clicks on an empty location, then he is navigated to the location details screen with empty data.
 
### Solution

The user should be navigated to the location details screen only when the location is available (aka has an `id` > 0 - since the `mapper` maps the null id value to `0` value.

### Implementation

- Added a check before navigating to location details screen based on the `id` value.

### Testing

- Navigate to character details screen of a user that has an unavailable `origin` or `location`. 
- Click to an `unavailable` location. You should now not be prompted to location details screen.
- Click on a `valid` location. You should be navigated to the location details screen.