### PR TITLE
Impl: Clean up design-system module build.gradle.kts file

### DIFF
--- a/core/design-system/build.gradle.kts
+++ b/core/design-system/build.gradle.kts
@@ -1,58 +1,16 @@
 plugins {
-    id("com.android.library")
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.custom.android.library)
+    alias(libs.plugins.custom.android.compose)
     alias(libs.plugins.compose.compiler)
 }
 
 android {
     namespace = "com.stathis.designsystem"
-    compileSdk = 34
-
-    defaultConfig {
-        minSdk = 21
-        testOptions.targetSdk = 34
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        vectorDrawables {
-            useSupportLibrary = true
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.androidxComposeCompiler.get()
-    }
 }
 
 dependencies {
     implementation(projects.core.util)
 
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.material3)
-
     implementation(libs.coil)
-
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
 }


### PR DESCRIPTION
## Description

The project utilizes gradle convention plugins so that they can be re-used accross different modules. The `design-system` build.gradle.kts file didn't use the convention plugin.

## Implementation
- Clean up `build.gradle.kts` file inside `design-system` module.