### PR TITLE
[Dependency Updates] Add dependency updates grouping to renovate.json

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.0"
 composeBom = "2025.02.00"
-androidGradlePlugin = "8.8.1"
 androidTools = "31.8.1"
 androidxComposeCompiler = "1.7.8"
 composeNavigation = "2.8.7"
@@ -71,7 +70,7 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plugin", version.ref = "room" }
 
 # Dependencies of the included build-logic
-android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
+android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 android-tools-common = { group = "com.android.tools", name = "common", version.ref = "androidTools" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,49 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "rebaseWhen": "behind-base-branch",
+  "addLabels": [
+    "Dependency Updates"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Kotlin & Friends Updates \uD800\uDC2A\uD800\uDC2A\uD800\uDC2A",
+      "matchPackageNames": [
+        "org.jetbrains.kotlin",
+        "com.google.devtools.ksp",
+        "org.jetbrains.kotlin.plugin.compose"
+      ]
+    },
+    {
+      "groupName": "AGP & Friends Updates \uD800\uDC2A\uD800\uDC2A\uD800\uDC2A",
+      "matchPackageNames": [
+        "com.android.application",
+        "com.android.library",
+        "com.android.tools.build"
+      ]
+    },
+    {
+      "groupName": "AndroidX & Jetpack Compose Updates",
+      "matchPackageNames": [
+        "androidx.core",
+        "androidx.lifecycle",
+        "androidx.activity/activity-compose",
+        "androidx.compose",
+        "androidx.compose.ui",
+        "androidx.compose.material3",
+        "androidx.navigation/navigation-compose"
+      ]
+    },
+    {
+      "groupName": "Testing Updates \uD83E\uDDEA",
+      "matchPackageNames": [
+        "org.junit.jupiter",
+        "androidx.test.ext",
+        "androidx.test.espresso",
+        "org.jetbrains.kotlinx/kotlinx-coroutines-test",
+        "io.mockk"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
### Description

This PR enhances the `renovate.json` file to contain dependency updates groupings.

The groupings created under `renovate.json` file are:

- Kotlin & Friends
- AGP & Friends
- AndroidX & Jetpack Compose
- Testing